### PR TITLE
update task versions for index and .nojekyll creation

### DIFF
--- a/{{cookiecutter.project_folder}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_folder}}/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: compas-dev/compas-actions.docs@v1.0.2
+      - uses: compas-dev/compas-actions.docs@v1.1.0
         id: docs
         with:
           dest: deploy
@@ -47,7 +47,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: compas-dev/compas-actions.docversions@v1.0.2
+      - uses: compas-dev/compas-actions.docversions@v1.1.0
         with:
           current_version: ${{ '{{' }} needs.build.outputs.current_version {{ '}}' }}
 


### PR DESCRIPTION
Moving creation of index.html and .nojekyll to `docs` from `docsversion`, so these files will be created upfront at first commit to main branch
https://github.com/compas-dev/compas-actions.docs/commit/679c82cc87b93bcb643e3d8d9c86d0ad2ffa3969
https://github.com/compas-dev/compas-actions.docversions/commit/5bb1ef1754607cd38a483f56b54c7ee2223e517b